### PR TITLE
Add `os(visionOS)` to os checks

### DIFF
--- a/IntegrationTests/allocation-counter-tests-framework/template/scaffolding.swift
+++ b/IntegrationTests/allocation-counter-tests-framework/template/scaffolding.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import AtomicCounter
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
 import Darwin
 #else
 import Glibc
@@ -52,7 +52,7 @@ func measureAll(_ fn: () -> Int) -> [[String: Int]] {
         AtomicCounter.reset_free_counter()
         AtomicCounter.reset_malloc_counter()
         AtomicCounter.reset_malloc_bytes_counter()
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
         autoreleasepool {
             _ = fn()
         }

--- a/IntegrationTests/tests_02_syscall_wrappers/test_01_syscall_wrapper_fast.sh
+++ b/IntegrationTests/tests_02_syscall_wrappers/test_01_syscall_wrapper_fast.sh
@@ -31,7 +31,7 @@ mkdir "$tmpdir/syscallwrapper"
 cd "$tmpdir/syscallwrapper"
 swift package init --type=executable
 cat > "$tmpdir/syscallwrapper/Sources/syscallwrapper/main.swift" <<EOF
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
 import Darwin
 #else
 import Glibc

--- a/IntegrationTests/tests_02_syscall_wrappers/test_02_unacceptable_errnos.sh
+++ b/IntegrationTests/tests_02_syscall_wrappers/test_02_unacceptable_errnos.sh
@@ -31,7 +31,7 @@ mkdir "$tmpdir/syscallwrapper"
 cd "$tmpdir/syscallwrapper"
 swift package init --type=executable
 cat > "$tmpdir/syscallwrapper/Sources/syscallwrapper/main.swift" <<EOF
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
 import Darwin
 #else
 import Glibc

--- a/IntegrationTests/tests_02_syscall_wrappers/test_03_unacceptable_read_errnos.sh
+++ b/IntegrationTests/tests_02_syscall_wrappers/test_03_unacceptable_read_errnos.sh
@@ -31,7 +31,7 @@ mkdir "$tmpdir/syscallwrapper"
 cd "$tmpdir/syscallwrapper"
 swift package init --type=executable
 cat > "$tmpdir/syscallwrapper/Sources/syscallwrapper/main.swift" <<EOF
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
 import Darwin
 #else
 import Glibc

--- a/Sources/NIOConcurrencyHelpers/atomics.swift
+++ b/Sources/NIOConcurrencyHelpers/atomics.swift
@@ -14,7 +14,7 @@
 
 import CNIOAtomics
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
 import Darwin
 fileprivate func sys_sched_yield() {
     pthread_yield_np()

--- a/Sources/NIOConcurrencyHelpers/lock.swift
+++ b/Sources/NIOConcurrencyHelpers/lock.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
 import Darwin
 #elseif os(Windows)
 import ucrt

--- a/Sources/NIOCore/BSDSocketAPI.swift
+++ b/Sources/NIOCore/BSDSocketAPI.swift
@@ -60,7 +60,7 @@ import CNIOLinux
 
 private let sysInet_ntop: @convention(c) (CInt, UnsafeRawPointer?, UnsafeMutablePointer<CChar>?, socklen_t) -> UnsafePointer<CChar>? = inet_ntop
 private let sysInet_pton: @convention(c) (CInt, UnsafePointer<CChar>?, UnsafeMutableRawPointer?) -> CInt = inet_pton
-#elseif os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#elseif os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
 import Darwin
 
 private let sysInet_ntop: @convention(c) (CInt, UnsafeRawPointer?, UnsafeMutablePointer<CChar>?, socklen_t) -> UnsafePointer<CChar>? = inet_ntop
@@ -302,7 +302,7 @@ extension NIOBSDSocket.Option {
 }
 #endif
 
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS) || os(visionOS)
 extension NIOBSDSocket.Option {
     /// Get information about the TCP connection.
     public static let tcp_connection_info: NIOBSDSocket.Option =

--- a/Sources/NIOCore/ByteBuffer-core.swift
+++ b/Sources/NIOCore/ByteBuffer-core.swift
@@ -14,7 +14,7 @@
 
 #if os(Windows)
 import ucrt
-#elseif os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#elseif os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
 import Darwin
 #else
 import Glibc

--- a/Sources/NIOCore/FileHandle.swift
+++ b/Sources/NIOCore/FileHandle.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 #if os(Windows)
 import ucrt
-#elseif os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#elseif os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
 import Darwin
 #elseif os(Linux) || os(Android)
 import Glibc

--- a/Sources/NIOCore/FileRegion.swift
+++ b/Sources/NIOCore/FileRegion.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 #if os(Windows)
 import ucrt
-#elseif os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#elseif os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
 import Darwin
 #elseif os(Linux) || os(Android)
 import Glibc

--- a/Sources/NIOCore/IO.swift
+++ b/Sources/NIOCore/IO.swift
@@ -16,7 +16,7 @@
 import typealias WinSDK.DWORD
 #elseif os(Linux) || os(Android)
 import Glibc
-#elseif os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#elseif os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
 import Darwin
 #endif
 

--- a/Sources/NIOCore/Interfaces.swift
+++ b/Sources/NIOCore/Interfaces.swift
@@ -14,7 +14,7 @@
 #if os(Linux) || os(FreeBSD) || os(Android)
 import Glibc
 import CNIOLinux
-#elseif os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#elseif os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
 import Darwin
 #elseif os(Windows)
 import let WinSDK.AF_INET
@@ -35,7 +35,7 @@ private extension ifaddrs {
     var dstaddr: UnsafeMutablePointer<sockaddr>? {
         #if os(Linux) || os(Android)
         return self.ifa_ifu.ifu_dstaddr
-        #elseif os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        #elseif os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
         return self.ifa_dstaddr
         #endif
     }
@@ -43,7 +43,7 @@ private extension ifaddrs {
     var broadaddr: UnsafeMutablePointer<sockaddr>? {
         #if os(Linux) || os(Android)
         return self.ifa_ifu.ifu_broadaddr
-        #elseif os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        #elseif os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
         return self.ifa_dstaddr
         #endif
     }

--- a/Sources/NIOCore/SocketAddresses.swift
+++ b/Sources/NIOCore/SocketAddresses.swift
@@ -24,7 +24,7 @@ import struct WinSDK.ADDRINFOW
 import struct WinSDK.in_addr_t
 
 import typealias WinSDK.u_short
-#elseif os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#elseif os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
 import Darwin
 #elseif os(Linux) || os(FreeBSD) || os(Android)
 import Glibc

--- a/Sources/NIOCore/SocketOptionProvider.swift
+++ b/Sources/NIOCore/SocketOptionProvider.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
 import Darwin
 #elseif os(Linux) || os(Android)
 import Glibc
@@ -269,7 +269,7 @@ extension SocketOptionProvider {
         }
     #endif
 
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS) || os(visionOS)
         /// Gets the value of the socket option TCP_CONNECTION_INFO.
         ///
         /// This socket option cannot be set.

--- a/Sources/NIOCore/SystemCallHelpers.swift
+++ b/Sources/NIOCore/SystemCallHelpers.swift
@@ -19,7 +19,7 @@
 //
 // This file arguably shouldn't be here in NIOCore, but due to early design decisions we accidentally exposed a few types that
 // know about system calls into the core API (looking at you, FileHandle). As a result we need support for a small number of system calls.
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
 import Darwin.C
 #elseif os(Linux) || os(FreeBSD) || os(Android)
 import Glibc

--- a/Sources/NIOCore/Utilities.swift
+++ b/Sources/NIOCore/Utilities.swift
@@ -30,7 +30,7 @@ import struct WinSDK.SYSTEM_LOGICAL_PROCESSOR_INFORMATION
 import struct WinSDK.ULONG
 
 import typealias WinSDK.DWORD
-#elseif os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#elseif os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
 import Darwin
 #endif
 

--- a/Sources/NIOPosix/BSDSocketAPIPosix.swift
+++ b/Sources/NIOPosix/BSDSocketAPIPosix.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 import NIOCore
 
-#if os(Linux) || os(Android) || os(FreeBSD) || os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(Linux) || os(Android) || os(FreeBSD) || os(iOS) || os(macOS) || os(tvOS) || os(watchOS) || os(visionOS)
 
 extension Shutdown {
     internal var cValue: CInt {
@@ -211,7 +211,7 @@ extension NIOBSDSocket {
     }
 }
 
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS) || os(visionOS)
 import CNIODarwin
 private let CMSG_FIRSTHDR = CNIODarwin_CMSG_FIRSTHDR
 private let CMSG_NXTHDR = CNIODarwin_CMSG_NXTHDR

--- a/Sources/NIOPosix/ControlMessage.swift
+++ b/Sources/NIOPosix/ControlMessage.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 import NIOCore
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
 import CNIODarwin
 #elseif os(Linux) || os(FreeBSD) || os(Android)
 import CNIOLinux
@@ -157,7 +157,7 @@ struct ControlMessageParser {
         }
     }
     
-    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
     private static let ipv4TosType = IP_RECVTOS
     #else
     private static let ipv4TosType = IP_TOS    // Linux

--- a/Sources/NIOPosix/SelectableEventLoop.swift
+++ b/Sources/NIOPosix/SelectableEventLoop.swift
@@ -20,7 +20,7 @@ import _NIODataStructures
 /// Execute the given closure and ensure we release all auto pools if needed.
 @inlinable
 internal func withAutoReleasePool<T>(_ execute: () throws -> T) rethrows -> T {
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS) || os(visionOS)
     return try autoreleasepool {
         try execute()
     }

--- a/Sources/NIOPosix/SelectorGeneric.swift
+++ b/Sources/NIOPosix/SelectorGeneric.swift
@@ -83,7 +83,7 @@ struct SelectorEventSet: OptionSet, Equatable {
 }
 
 internal let isEarlyEOFDeliveryWorkingOnThisOS: Bool = {
-    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
     return false // rdar://53656794 , once fixed we need to do an OS version check here.
     #else
     return true
@@ -133,7 +133,7 @@ internal class Selector<R: Registration>  {
     var selectorFD: CInt = -1 // -1 == we're closed
 
     // Here we add the stored properties that are used by the specific backends
-    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
     typealias EventType = kevent
     #elseif os(Linux) || os(Android)
     #if !SWIFTNIO_USE_IO_URING

--- a/Sources/NIOPosix/SelectorKqueue.swift
+++ b/Sources/NIOPosix/SelectorKqueue.swift
@@ -14,7 +14,7 @@
 
 import NIOCore
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
 
 /// Represents the `kqueue` filters we might use:
 ///

--- a/Sources/NIOPosix/System.swift
+++ b/Sources/NIOPosix/System.swift
@@ -17,7 +17,7 @@
 
 import NIOCore
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
 @_exported import Darwin.C
 import CNIODarwin
 internal typealias MMsgHdr = CNIODarwin_mmsghdr
@@ -109,7 +109,7 @@ private let sysSocketpair: @convention(c) (CInt, CInt, CInt, UnsafeMutablePointe
 private let sysFstat: @convention(c) (CInt, UnsafeMutablePointer<stat>) -> CInt = fstat
 private let sysStat: @convention(c) (UnsafePointer<CChar>, UnsafeMutablePointer<stat>) -> CInt = stat
 private let sysUnlink: @convention(c) (UnsafePointer<CChar>) -> CInt = unlink
-#elseif os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(Android)
+#elseif os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS) || os(Android)
 private let sysFstat: @convention(c) (CInt, UnsafeMutablePointer<stat>?) -> CInt = fstat
 private let sysStat: @convention(c) (UnsafePointer<CChar>?, UnsafeMutablePointer<stat>?) -> CInt = stat
 private let sysUnlink: @convention(c) (UnsafePointer<CChar>?) -> CInt = unlink
@@ -117,7 +117,7 @@ private let sysUnlink: @convention(c) (UnsafePointer<CChar>?) -> CInt = unlink
 #if os(Linux) || os(Android)
 private let sysSendMmsg: @convention(c) (CInt, UnsafeMutablePointer<CNIOLinux_mmsghdr>?, CUnsignedInt, CInt) -> CInt = CNIOLinux_sendmmsg
 private let sysRecvMmsg: @convention(c) (CInt, UnsafeMutablePointer<CNIOLinux_mmsghdr>?, CUnsignedInt, CInt, UnsafeMutablePointer<timespec>?) -> CInt  = CNIOLinux_recvmmsg
-#elseif os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#elseif os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
 private let sysKevent = kevent
 private let sysSendMmsg: @convention(c) (CInt, UnsafeMutablePointer<CNIODarwin_mmsghdr>?, CUnsignedInt, CInt) -> CInt = CNIODarwin_sendmmsg
 private let sysRecvMmsg: @convention(c) (CInt, UnsafeMutablePointer<CNIODarwin_mmsghdr>?, CUnsignedInt, CInt, UnsafeMutablePointer<timespec>?) -> CInt = CNIODarwin_recvmmsg
@@ -250,7 +250,7 @@ internal func syscallForbiddingEINVAL<T: FixedWidthInteger>(where function: Stri
 }
 
 internal enum Posix {
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
     static let UIO_MAXIOV: Int = 1024
     static let SHUT_RD: CInt = CInt(Darwin.SHUT_RD)
     static let SHUT_WR: CInt = CInt(Darwin.SHUT_WR)
@@ -499,7 +499,7 @@ internal enum Posix {
         var written: off_t = 0
         do {
             _ = try syscall(blocking: false) { () -> ssize_t in
-                #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+                #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
                     var w: off_t = off_t(count)
                     let result: CInt = Darwin.sendfile(fd, descriptor, offset, &w, nil, 0)
                     written = w
@@ -635,7 +635,7 @@ internal extension Posix {
 }
 #endif
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
 internal enum KQueue {
 
     // TODO: Figure out how to specify a typealias to the kevent struct without run into trouble with the swift compiler

--- a/Sources/NIOPosix/ThreadPosix.swift
+++ b/Sources/NIOPosix/ThreadPosix.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(Linux) || os(Android) || os(FreeBSD) || os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if os(Linux) || os(Android) || os(FreeBSD) || os(iOS) || os(macOS) || os(tvOS) || os(watchOS) || os(visionOS)
 
 #if os(Linux) || os(Android)
 import CNIOLinux
@@ -20,7 +20,7 @@ import CNIOLinux
 private let sys_pthread_getname_np = CNIOLinux_pthread_getname_np
 private let sys_pthread_setname_np = CNIOLinux_pthread_setname_np
 private typealias ThreadDestructor = @convention(c) (UnsafeMutableRawPointer?) -> UnsafeMutableRawPointer?
-#elseif os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#elseif os(iOS) || os(macOS) || os(tvOS) || os(watchOS) || os(visionOS)
 private let sys_pthread_getname_np = pthread_getname_np
 // Emulate the same method signature as pthread_setname_np on Linux.
 private func sys_pthread_setname_np(_ p: pthread_t, _ pointer: UnsafePointer<Int8>) -> Int32 {
@@ -36,7 +36,7 @@ private typealias ThreadDestructor = @convention(c) (UnsafeMutableRawPointer) ->
 private func sysPthread_create(handle: UnsafeMutablePointer<pthread_t?>,
                                destructor: @escaping ThreadDestructor,
                                args: UnsafeMutableRawPointer?) -> CInt {
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS) || os(visionOS)
     return pthread_create(handle, nil, destructor, args)
     #else
     var handleLinux = pthread_t()
@@ -55,7 +55,7 @@ typealias ThreadOpsSystem = ThreadOpsPosix
 enum ThreadOpsPosix: ThreadOps {
     typealias ThreadHandle = pthread_t
     typealias ThreadSpecificKey = pthread_key_t
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS) || os(visionOS)
     typealias ThreadSpecificKeyDestructor = @convention(c) (UnsafeMutableRawPointer) -> Void
     #else
     typealias ThreadSpecificKeyDestructor = @convention(c) (UnsafeMutableRawPointer?) -> Void

--- a/Sources/NIOWebSocket/Base64.swift
+++ b/Sources/NIOWebSocket/Base64.swift
@@ -148,7 +148,7 @@ extension String {
 // this declaration on having the 5.3 compiler. This has caused a number of build issues. While updating
 // to newer Xcodes does work, we can save ourselves some hassle and just wait until 5.4 to get this
 // enhancement on Apple platforms.
-#if (compiler(>=5.3) && !(os(macOS) || os(iOS) || os(tvOS) || os(watchOS))) || compiler(>=5.4)
+#if (compiler(>=5.3) && !(os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(visionOS))) || compiler(>=5.4)
 extension String {
     
   @inlinable

--- a/Tests/NIOConcurrencyHelpersTests/NIOConcurrencyHelpersTests.swift
+++ b/Tests/NIOConcurrencyHelpersTests/NIOConcurrencyHelpersTests.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
 import Darwin
 #else
 import Glibc

--- a/Tests/NIOPosixTests/HappyEyeballsTest.swift
+++ b/Tests/NIOPosixTests/HappyEyeballsTest.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
     import Darwin
 #else
     import Glibc

--- a/Tests/NIOPosixTests/SocketOptionProviderTest.swift
+++ b/Tests/NIOPosixTests/SocketOptionProviderTest.swift
@@ -282,7 +282,7 @@ final class SocketOptionProviderTest: XCTestCase {
 
     func testTCPConnectionInfo() throws {
         // This test only runs on Darwin.
-        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
         let channel = self.clientChannel! as! SocketOptionProvider
         let tcpConnectionInfo = try assertNoThrowWithValue(channel.getTCPConnectionInfo().wait())
 

--- a/Tests/NIOPosixTests/StreamChannelsTest.swift
+++ b/Tests/NIOPosixTests/StreamChannelsTest.swift
@@ -895,7 +895,7 @@ private func assertNoSelectorChanges(fd: CInt, selector: NIOPosix.Selector<NIORe
         let description: String
     }
 
-    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(FreeBSD)
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS) || os(FreeBSD)
     var ev: kevent = .init()
     var nothing: timespec = .init()
     let numberOfEvents = try KQueue.kevent(kq: fd, changelist: nil, nchanges: 0, eventlist: &ev, nevents: 1, timeout: &nothing)

--- a/Tests/NIOPosixTests/SystemTest.swift
+++ b/Tests/NIOPosixTests/SystemTest.swift
@@ -47,7 +47,7 @@ class SystemTest: XCTestCase {
         }
     }
 
-    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
     // Example twin data options captured on macOS
     private static let cmsghdrExample: [UInt8] = [0x10, 0x00, 0x00, 0x00, // Length 16 including header
                                                   0x00, 0x00, 0x00, 0x00, // IPPROTO_IP


### PR DESCRIPTION
Adds `os(visionOS)` to all code sections where such checks are performed

### Motivation:

These checks separated Linux/Windows/Apple codepaths, e.g. linking to `Darwin` or `Glibc`. They had to be extended to categorise visionOS under Apple OSs properly.

### Modifications:

`os(XXX)` checks were extended to account for `os(visionOS)`

### Result:

SwiftNIO 2.40.0 works on VisionOS 🎉
